### PR TITLE
Implement option for keyboard input (#3)

### DIFF
--- a/app/src/main/java/tech/almost_senseless/voskle/MainActivity.kt
+++ b/app/src/main/java/tech/almost_senseless/voskle/MainActivity.kt
@@ -22,8 +22,10 @@ import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.selection.toggleable
 import androidx.compose.material3.Button
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -32,6 +34,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.LiveRegionMode
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.liveRegion
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
@@ -118,6 +121,7 @@ class MainActivity : ComponentActivity() {
                 Column(
                     modifier = Modifier
                         .fillMaxSize()
+                        .fillMaxSize()
                         .background(MaterialTheme.colorScheme.background)
                 ) {
 
@@ -145,6 +149,24 @@ class MainActivity : ComponentActivity() {
                                 ) {
                                     Text(text = stringResource(id = R.string.settings))
                                 }
+                                Column(
+                                    modifier = Modifier
+                                        .padding(horizontal = 4.dp)
+                                        .toggleable(
+                                            value = state.keyboardInput,
+                                            role = Role.Switch,
+                                            onValueChange = {
+                                                if (state.isRecording && !state.keyboardInput)
+                                                    viewModel.getVoskHub().toggleRecording()
+                                                viewModel.onAction(VLTAction.SetKeyboardInput(
+                                                    !state.keyboardInput
+                                                ))
+                                            }
+                                        ),
+                                ) {
+                                    Switch(checked = state.keyboardInput, null)
+                                    Text(text = stringResource(id = R.string.keyboard_input))
+                                }
                             }
                         }
 
@@ -169,6 +191,24 @@ class MainActivity : ComponentActivity() {
                                 ) {
                                     Text(text = stringResource(id = R.string.settings))
                                 }
+                                Row(
+                                    modifier = Modifier
+                                        .padding(vertical = 4.dp)
+                                        .toggleable(
+                                            value = state.keyboardInput,
+                                            role = Role.Switch,
+                                            onValueChange = { enabled ->
+                                                if (state.isRecording && !state.keyboardInput)
+                                                    viewModel.getVoskHub().toggleRecording()
+                                                viewModel.onAction(VLTAction.SetKeyboardInput(
+                                                    !state.keyboardInput
+                                                ))
+                                            }
+                                        ),
+                                ) {
+                                    Switch(checked = state.keyboardInput, null)
+                                    Text(text = stringResource(id = R.string.keyboard_input))
+                                }
                             }
                         }
                     }
@@ -190,7 +230,7 @@ class MainActivity : ComponentActivity() {
 
                                 Row {
                                     Button(
-                                        enabled = viewModel.state.modelLoaded,
+                                        enabled = viewModel.state.modelLoaded && !state.keyboardInput,
                                         onClick = {
                                             if (checkSelfPermission(android.Manifest.permission.RECORD_AUDIO) != PackageManager.PERMISSION_GRANTED && !state.isRecording) {
                                                 viewModel.onAction(

--- a/app/src/main/java/tech/almost_senseless/voskle/VLTAction.kt
+++ b/app/src/main/java/tech/almost_senseless/voskle/VLTAction.kt
@@ -22,4 +22,6 @@ sealed class VLTAction{
     data class ToggleAutoscroll(val autoscroll: Boolean): VLTAction()
     data class RegisterVoskHub(val voskHub: VoskHub): VLTAction()
     data class UpdateFetchState(val state: FetchState): VLTAction()
+    data class SetKeyboardInput(val enabled: Boolean): VLTAction()
+    data class EditTranscript(val text: String): VLTAction()
 }

--- a/app/src/main/java/tech/almost_senseless/voskle/VLTState.kt
+++ b/app/src/main/java/tech/almost_senseless/voskle/VLTState.kt
@@ -1,6 +1,5 @@
 package tech.almost_senseless.voskle
 
-import androidx.compose.foundation.ScrollState
 import tech.almost_senseless.voskle.vosklib.VoskHub
 
 data class VLTState(
@@ -15,4 +14,5 @@ data class VLTState(
     val error: ErrorKind? = null,
     val voskHubInstance: VoskHub? = null,
     val fetchState: FetchState = FetchState.NO_MODEL,
+    val keyboardInput: Boolean = false,
 )

--- a/app/src/main/java/tech/almost_senseless/voskle/VLTViewModel.kt
+++ b/app/src/main/java/tech/almost_senseless/voskle/VLTViewModel.kt
@@ -40,6 +40,8 @@ class VLTViewModel(private val userPreferences: UserPreferencesRepository, @Supp
             is VLTAction.ToggleAutoscroll -> toggleAutoscroll(action.autoscroll)
             is VLTAction.RegisterVoskHub -> registerVoskHub(action.voskHub)
             is VLTAction.UpdateFetchState -> updateFetchstate(action.state)
+            is VLTAction.SetKeyboardInput -> setKeyboardInput(action.enabled)
+            is VLTAction.EditTranscript -> editTranscript(action.text)
         }
     }
 
@@ -163,6 +165,14 @@ class VLTViewModel(private val userPreferences: UserPreferencesRepository, @Supp
     override fun onCleared(){
         this.state.voskHubInstance?.reset()
         super.onCleared()
+    }
+
+    private fun setKeyboardInput(enabled: Boolean) {
+        state = state.copy(keyboardInput = enabled)
+    }
+
+    fun editTranscript(text: String) {
+        state = state.copy(transcript = text)
     }
 }
 

--- a/app/src/main/java/tech/almost_senseless/voskle/ui/customComposables/Textarea.kt
+++ b/app/src/main/java/tech/almost_senseless/voskle/ui/customComposables/Textarea.kt
@@ -7,13 +7,16 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.LocalTextStyle
+import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.em
+import tech.almost_senseless.voskle.R
 import tech.almost_senseless.voskle.VLTAction
 import tech.almost_senseless.voskle.VLTState
 import tech.almost_senseless.voskle.data.UserPreferences
@@ -34,8 +37,15 @@ fun Textarea(
     }
     TextField(
         value = state.transcript,
-        onValueChange = { onAction(VLTAction.UpdateTranscript(it)) },
-        readOnly = true,
+        onValueChange = {
+            if (state.keyboardInput) {
+                onAction(VLTAction.EditTranscript(it))
+            } else {
+                onAction(VLTAction.UpdateTranscript(it))
+            }
+                        },
+        readOnly = !state.keyboardInput,
+        label = { Text(text = stringResource(id = R.string.transcript_label)) },
         modifier = Modifier
             .fillMaxWidth()
             .padding(horizontal = 8.dp)

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -44,4 +44,6 @@
     <string name="unpacking_state">Verarbeite Modell...</string>
     <string name="no_model_loaded_state">Kein Modell geladen.</string>
     <string name="ready_to_transcribe_state">Betriebsbereit.</string>
+    <string name="keyboard_input">Tastatureingabe</string>
+    <string name="transcript_label">Transkript:</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -44,4 +44,6 @@
     <string name="unpacking_state">Processing model...</string>
     <string name="no_model_loaded_state">No model loaded.</string>
     <string name="ready_to_transcribe_state">Ready to transcribe.</string>
+    <string name="keyboard_input">Keyboard input</string>
+    <string name="transcript_label">Transcript:</string>
 </resources>


### PR DESCRIPTION
This adds a switch to the UI that allows toggling the `readonly` flag of the text input so that one can edit the transcript with a keyboard.

The transcription gets stopped and disabled while keyboard input is enabled.