### PR TITLE
Correct placement of the cursor implemented

### DIFF
--- a/app/src/main/java/tech/almost_senseless/voskle/MainActivity.kt
+++ b/app/src/main/java/tech/almost_senseless/voskle/MainActivity.kt
@@ -90,7 +90,8 @@ class MainActivity : ComponentActivity() {
                 )
                 val state = viewModel.state
                 val settings = viewModel.settings.collectAsState(initial = UserPreferences())
-                val focusRequester = FocusRequester()
+                val recordButtonFocusRequester = FocusRequester()
+                val textareaFocusRequester = FocusRequester()
 
                 LaunchedEffect(
                     viewModel.getVoskHub().isModelAvailable(),
@@ -142,7 +143,7 @@ class MainActivity : ComponentActivity() {
                     loses focus.
                      */
                     if (!state.isFocused && state.transcriptFocused) {
-                        focusRequester.requestFocus()
+                        recordButtonFocusRequester.requestFocus()
                     }
                 }
 
@@ -197,6 +198,10 @@ class MainActivity : ComponentActivity() {
                                             value = state.keyboardInput,
                                             role = Role.Switch,
                                             onValueChange = {
+                                                if (!state.keyboardInput) {
+                                                    textareaFocusRequester.requestFocus()
+                                                }
+
                                                 if (state.isRecording && !state.keyboardInput) {
                                                     viewModel.onAction(
                                                         VLTAction.SetResumeRecording(
@@ -210,6 +215,10 @@ class MainActivity : ComponentActivity() {
                                                     viewModel.getVoskHub().toggleRecording()
                                                     viewModel.onAction(VLTAction.SetResumeRecording(false))
                                                 }
+
+                                                // Trigger the insertion of a new line if necessary
+                                                viewModel.onAction(VLTAction.UpdateTranscript("\n"))
+
                                                 viewModel.onAction(
                                                     VLTAction.SetKeyboardInput(
                                                         !state.keyboardInput
@@ -252,14 +261,23 @@ class MainActivity : ComponentActivity() {
                                             value = state.keyboardInput,
                                             role = Role.Switch,
                                             onValueChange = {
+                                                if (!state.keyboardInput) {
+                                                    textareaFocusRequester.requestFocus()
+                                                }
+
                                                 if (state.isRecording && !state.keyboardInput) {
                                                     viewModel.onAction(VLTAction.SetResumeRecording(true))
                                                     viewModel.getVoskHub().toggleRecording()
                                                 }
+
                                                 if (state.keyboardInput && state.resumeRecording) {
                                                     viewModel.getVoskHub().toggleRecording()
                                                     viewModel.onAction(VLTAction.SetResumeRecording(false))
                                                 }
+
+                                                // Trigger the insertion of a new line if necessary
+                                                viewModel.onAction(VLTAction.UpdateTranscript("\n"))
+
                                                 viewModel.onAction(
                                                     VLTAction.SetKeyboardInput(
                                                         !state.keyboardInput
@@ -290,6 +308,7 @@ class MainActivity : ComponentActivity() {
                                         .onFocusChanged {
                                             viewModel.onAction(VLTAction.SetTranscriptFocused(it.isFocused))
                                         }
+                                        .focusRequester(textareaFocusRequester)
                                         .weight(5f)
                                 )
 
@@ -310,7 +329,7 @@ class MainActivity : ComponentActivity() {
                                         modifier = Modifier
                                             .padding(8.dp)
                                             .weight(1f)
-                                            .focusRequester(focusRequester)
+                                            .focusRequester(recordButtonFocusRequester)
                                     ) {
                                         val transcribeButtonLabel =
                                             if (viewModel.state.modelLoaded && viewModel.state.isRecording) stringResource(
@@ -356,6 +375,7 @@ class MainActivity : ComponentActivity() {
                                         .onFocusChanged {
                                             viewModel.onAction(VLTAction.SetTranscriptFocused(it.isFocused))
                                         }
+                                        .focusRequester(textareaFocusRequester)
                                         .weight(8f)
                                 )
                                 Row(
@@ -380,7 +400,7 @@ class MainActivity : ComponentActivity() {
                                         modifier = Modifier
                                             .padding(horizontal = 8.dp)
                                             .weight(1f)
-                                            .focusRequester(focusRequester)
+                                            .focusRequester(recordButtonFocusRequester)
                                     ) {
                                         val transcribeButtonLabel =
                                             if (viewModel.state.modelLoaded && viewModel.state.isRecording) stringResource(

--- a/app/src/main/java/tech/almost_senseless/voskle/VLTAction.kt
+++ b/app/src/main/java/tech/almost_senseless/voskle/VLTAction.kt
@@ -28,4 +28,6 @@ sealed class VLTAction{
     data class SetFocusedState(val focused: Boolean): VLTAction()
     data class SetTranscriptFocused(val focused: Boolean): VLTAction()
     data class SetResumeRecording(val resume: Boolean): VLTAction()
+    object MoveCursorLeft: VLTAction()
+    object MoveCursorRight: VLTAction()
 }

--- a/app/src/main/java/tech/almost_senseless/voskle/VLTState.kt
+++ b/app/src/main/java/tech/almost_senseless/voskle/VLTState.kt
@@ -1,5 +1,7 @@
 package tech.almost_senseless.voskle
 
+import androidx.compose.ui.text.TextRange
+import androidx.compose.ui.text.input.TextFieldValue
 import tech.almost_senseless.voskle.vosklib.VoskHub
 
 data class VLTState(
@@ -18,4 +20,5 @@ data class VLTState(
     val isFocused: Boolean = true,
     val transcriptFocused: Boolean = false,
     val resumeRecording: Boolean = false,
+    val textFieldValue: TextFieldValue = TextFieldValue(text = "", selection = TextRange.Zero)
 )

--- a/app/src/main/java/tech/almost_senseless/voskle/ui/customComposables/Textarea.kt
+++ b/app/src/main/java/tech/almost_senseless/voskle/ui/customComposables/Textarea.kt
@@ -1,9 +1,12 @@
 package tech.almost_senseless.voskle.ui.customComposables
 
 import androidx.compose.foundation.border
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.LocalTextStyle
@@ -13,7 +16,12 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.onKeyEvent
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.TextRange
+import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.em
 import tech.almost_senseless.voskle.R
@@ -35,13 +43,14 @@ fun Textarea(
             scrollState.animateScrollTo(scrollState.maxValue)
         }
     }
+
     TextField(
-        value = state.transcript,
+        value = state.textFieldValue,
         onValueChange = {
             if (state.keyboardInput) {
-                onAction(VLTAction.EditTranscript(it))
+                onAction(VLTAction.EditTranscript(it.text))
             } else {
-                onAction(VLTAction.UpdateTranscript(it))
+                onAction(VLTAction.UpdateTranscript(it.text))
             }
                         },
         readOnly = !state.keyboardInput,
@@ -51,7 +60,30 @@ fun Textarea(
             .padding(horizontal = 8.dp)
             .border(width = 1.dp, color = Color.Black, shape = RoundedCornerShape(8.dp))
             .verticalScroll(scrollState)
+            .onKeyEvent {
+                val currentSelection = state.textFieldValue.selection.start
+                if (it.key == Key.DirectionLeft && TextRange(currentSelection) != TextRange.Zero) {
+                    onAction(VLTAction.MoveCursorLeft)
+                    true
+                } else {
+                    if (it.key == Key.DirectionRight && TextRange(currentSelection) != TextRange(
+                            state.transcript.length
+                        )
+                    ) {
+                        onAction(VLTAction.MoveCursorRight)
+                        true
+                    } else {
+                        false
+                    }
+                }
+            }
             .then(modifier),
-        textStyle = LocalTextStyle.current.copy(fontSize = settings.transcriptFontRatio.em)
+        textStyle = LocalTextStyle.current.copy(fontSize = settings.transcriptFontRatio.em),
+        keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
+        keyboardActions = KeyboardActions(
+            onDone = {
+                onAction(VLTAction.SetKeyboardInput(false))
+            }
+        )
     )
 }

--- a/app/src/main/java/tech/almost_senseless/voskle/ui/customComposables/Textarea.kt
+++ b/app/src/main/java/tech/almost_senseless/voskle/ui/customComposables/Textarea.kt
@@ -82,6 +82,10 @@ fun Textarea(
         keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
         keyboardActions = KeyboardActions(
             onDone = {
+                if (state.resumeRecording) {
+                    onAction(VLTAction.SetResumeRecording(false))
+                    state.voskHubInstance!!.toggleRecording()
+                }
                 onAction(VLTAction.SetKeyboardInput(false))
             }
         )


### PR DESCRIPTION
The cursor now gets placed at the end of the transcript, unless keyboard input is active, in which case the user can navigate character-by-character using the left and right arrow keys.

Additionally, the text field now receives focus when keyboard input gets activated.

If the user clicks on the Done button on the keyboard, keyboard input gets deactivated.