### PR TITLE
Changed contact email

### DIFF
--- a/app/src/main/java/tech/almost_senseless/voskle/MainActivity.kt
+++ b/app/src/main/java/tech/almost_senseless/voskle/MainActivity.kt
@@ -538,7 +538,7 @@ class MainActivity : ComponentActivity() {
         val text = "\n\n-----\n\nApp version: $appVersion ($appBuildInt)\nAndroid version: $androidSdkInt\nModel: $model"
         val intent = Intent(Intent.ACTION_SENDTO).apply {
             data = Uri.parse("mailto:")
-            putExtra(Intent.EXTRA_EMAIL, arrayOf("contact@tim-boettcher.email"))
+            putExtra(Intent.EXTRA_EMAIL, arrayOf("projects@almost-senseless.tech"))
             putExtra(Intent.EXTRA_SUBJECT, subject)
             putExtra(Intent.EXTRA_TEXT, text)
         }


### PR DESCRIPTION
When people click on the Contact us button, the email should now be addressed to an address dedicated to Almost Senseless Tech's projects.