### PR TITLE
Transcription results now get separated with .  instead of \n.

### DIFF
--- a/app/src/main/java/tech/almost_senseless/voskle/MainActivity.kt
+++ b/app/src/main/java/tech/almost_senseless/voskle/MainActivity.kt
@@ -215,8 +215,8 @@ class MainActivity : ComponentActivity() {
                                                     viewModel.onAction(VLTAction.SetResumeRecording(false))
                                                 }
 
-                                                // Trigger the insertion of a new line if necessary
-                                                viewModel.onAction(VLTAction.UpdateTranscript("\n"))
+                                                // Trigger the insertion of a result separator if appropriate
+                                                viewModel.onAction(VLTAction.UpdateTranscript(". "))
 
                                                 viewModel.onAction(
                                                     VLTAction.SetKeyboardInput(
@@ -274,8 +274,8 @@ class MainActivity : ComponentActivity() {
                                                     viewModel.onAction(VLTAction.SetResumeRecording(false))
                                                 }
 
-                                                // Trigger the insertion of a new line if necessary
-                                                viewModel.onAction(VLTAction.UpdateTranscript("\n"))
+                                                // Trigger the insertion of a result separator if appropriate.
+                                                viewModel.onAction(VLTAction.UpdateTranscript(". "))
 
                                                 viewModel.onAction(
                                                     VLTAction.SetKeyboardInput(

--- a/app/src/main/java/tech/almost_senseless/voskle/VLTAction.kt
+++ b/app/src/main/java/tech/almost_senseless/voskle/VLTAction.kt
@@ -5,7 +5,7 @@ import tech.almost_senseless.voskle.vosklib.VoskHub
 
 sealed class VLTAction{
     data class UpdateTranscript(val text: String): VLTAction()
-    data class UpdateLastLine(val text: String): VLTAction()
+    data class UpdateLastResult(val text: String): VLTAction()
     data class SetLanguage(val language: Languages): VLTAction()
     data class SetRecordingStatus(val status: Boolean): VLTAction()
     data class SetModelStatus(val status: Boolean): VLTAction()

--- a/app/src/main/java/tech/almost_senseless/voskle/VLTViewModel.kt
+++ b/app/src/main/java/tech/almost_senseless/voskle/VLTViewModel.kt
@@ -25,7 +25,7 @@ class VLTViewModel(private val userPreferences: UserPreferencesRepository, @Supp
     fun onAction(action: VLTAction){
         when(action){
             is VLTAction.UpdateTranscript -> updateTranscript(action.text)
-            is VLTAction.UpdateLastLine -> updateLastLine(action.text)
+            is VLTAction.UpdateLastResult -> updateLastResult(action.text)
             is VLTAction.SetLanguage -> setLanguage(action.language)
             is VLTAction.SetRecordingStatus -> setRecordingStatus(action.status)
             is VLTAction.SetModelStatus -> setModelStatus(action.status)
@@ -77,16 +77,16 @@ class VLTViewModel(private val userPreferences: UserPreferencesRepository, @Supp
 
     private fun updateTranscript(text: String) {
         var newTranscript = state.transcript
-        if (text != "\n") {
+        if (text != ". ") {
             if (text.isNotEmpty()) {
-                newTranscript = if (!state.transcript.contains('\n'))
-                    "$text\n"
+                newTranscript = if (!state.transcript.contains(". "))
+                    "$text. "
                 else
-                    newTranscript.replaceAfterLast("\n", "$text\n")
+                    newTranscript.replaceAfterLast(". ", "$text. ")
             }
         } else {
-            if (newTranscript.isNotEmpty() && !newTranscript.endsWith("\n"))
-                newTranscript = "$newTranscript\n"
+            if (newTranscript.isNotEmpty() && !newTranscript.endsWith(". "))
+                newTranscript = "$newTranscript. "
         }
         state = state.copy(transcript = newTranscript, textFieldValue = TextFieldValue(
             text = newTranscript,
@@ -94,13 +94,13 @@ class VLTViewModel(private val userPreferences: UserPreferencesRepository, @Supp
         ))
     }
 
-    private fun updateLastLine(text: String) {
+    private fun updateLastResult(text: String) {
         var newTranscript = state.transcript
         if (text.isNotEmpty()) {
-            newTranscript = if (!state.transcript.contains('\n'))
+            newTranscript = if (!state.transcript.contains(". "))
                 text
             else
-                newTranscript.replaceAfterLast("\n", text)
+                newTranscript.replaceAfterLast(". ", text)
         }
         state = state.copy(transcript = newTranscript, textFieldValue = TextFieldValue(
             text = newTranscript,

--- a/app/src/main/java/tech/almost_senseless/voskle/vosklib/VoskHub.kt
+++ b/app/src/main/java/tech/almost_senseless/voskle/vosklib/VoskHub.kt
@@ -134,7 +134,7 @@ class VoskHub (
     override fun onPartialResult(hypothesis: String?) {
         val data = JSONObject(hypothesis ?: "").get("partial").toString()
         if (this.viewModel != null && data.isNotEmpty())
-            updateApplicationState(VLTAction.UpdateLastLine(data))
+            updateApplicationState(VLTAction.UpdateLastResult(data))
     }
 
     override fun onResult(hypothesis: String?) {


### PR DESCRIPTION
This means the available screen space gets used more economically and the text has less irregular line lengths.

Resolves #21