### PR TITLE
Adjusted the handling of font sizes for the transcript

### DIFF
--- a/app/src/main/java/tech/almost_senseless/voskle/VLTAction.kt
+++ b/app/src/main/java/tech/almost_senseless/voskle/VLTAction.kt
@@ -1,5 +1,7 @@
 package tech.almost_senseless.voskle
 
+import androidx.compose.ui.unit.TextUnit
+import tech.almost_senseless.voskle.data.FontSizes
 import tech.almost_senseless.voskle.data.Languages
 import tech.almost_senseless.voskle.vosklib.VoskHub
 
@@ -13,7 +15,7 @@ sealed class VLTAction{
     data class ShowSettingsDialog(val display: Boolean): VLTAction()
     data class ShowPermissionsDialog(val display: Boolean): VLTAction()
     object ClearTranscript: VLTAction()
-    data class SetTranscriptFontRatio(val ratio: Float): VLTAction()
+    data class SetTranscriptFontSize(val size: FontSizes): VLTAction()
     data class ShowDownloadConfirmation(val display: Boolean): VLTAction()
     data class DownloadModel(val downloadFunction: (VLTViewModel, String) -> Unit, val modelPath: String): VLTAction()
     data class ShowDownloadSuccess(val display: Boolean): VLTAction()

--- a/app/src/main/java/tech/almost_senseless/voskle/VLTViewModel.kt
+++ b/app/src/main/java/tech/almost_senseless/voskle/VLTViewModel.kt
@@ -7,10 +7,12 @@ package tech.almost_senseless.voskle
  import androidx.compose.runtime.setValue
  import androidx.compose.ui.text.TextRange
  import androidx.compose.ui.text.input.TextFieldValue
+ import androidx.compose.ui.unit.TextUnit
  import androidx.lifecycle.ViewModel
  import androidx.lifecycle.ViewModelProvider
  import androidx.lifecycle.viewModelScope
  import kotlinx.coroutines.launch
+ import tech.almost_senseless.voskle.data.FontSizes
  import tech.almost_senseless.voskle.data.Languages
  import tech.almost_senseless.voskle.data.UserPreferencesRepository
  import tech.almost_senseless.voskle.vosklib.VoskHub
@@ -38,7 +40,7 @@ class VLTViewModel(private val userPreferences: UserPreferencesRepository, @Supp
             is VLTAction.ClearTranscript -> clearTranscript()
             is VLTAction.ShowSettingsDialog -> showSettingsDialog(action.display)
             is VLTAction.ShowPermissionsDialog -> showPermissionsDialog(action.display)
-            is VLTAction.SetTranscriptFontRatio -> setTranscriptFontRatio(action.ratio)
+            is VLTAction.SetTranscriptFontSize -> setTranscriptFontSize(action.size)
             is VLTAction.ShowDownloadConfirmation -> displayDownloadConfirmation(action.display)
             is VLTAction.DownloadModel -> downloadModel(action.downloadFunction, action.modelPath)
             is VLTAction.ShowDownloadSuccess -> displayDownloadSuccess(action.display)
@@ -147,9 +149,9 @@ class VLTViewModel(private val userPreferences: UserPreferencesRepository, @Supp
         downloadFunction(this, modelPath)
     }
 
-    private fun setTranscriptFontRatio(ratio: Float) {
+    private fun setTranscriptFontSize(size: FontSizes) {
         viewModelScope.launch {
-            userPreferences.updateTranscriptFontRatio(ratio)
+            userPreferences.updateTranscriptFontSize(size)
         }
     }
 

--- a/app/src/main/java/tech/almost_senseless/voskle/data/UserPreferencesRepository.kt
+++ b/app/src/main/java/tech/almost_senseless/voskle/data/UserPreferencesRepository.kt
@@ -1,12 +1,13 @@
 package tech.almost_senseless.voskle.data
 
 import android.util.Log
+import androidx.compose.ui.unit.TextUnit
+import androidx.compose.ui.unit.sp
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.emptyPreferences
-import androidx.datastore.preferences.core.floatPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
@@ -15,9 +16,16 @@ import java.io.IOException
 
 private const val TAG = "PreferencesRepo"
 
+enum class FontSizes(val size: TextUnit) {
+    SMALL(12.sp),
+    MEDIUM(16.sp),
+    LARGE(24.sp),
+    LARGEST(36.sp)
+}
+
 data class UserPreferences(
     val language: Languages = Languages.ENGLISH_US,
-    val transcriptFontRatio: Float = 3f,
+    val fontSize: FontSizes = FontSizes.MEDIUM,
     val autoscroll: Boolean = true,
     val stopRecordingOnFocusLoss: Boolean = true,
     val generateSpeakerLabels: Boolean = false
@@ -26,7 +34,7 @@ data class UserPreferences(
 class UserPreferencesRepository(private val dataStore: DataStore<Preferences>) {
     private object PreferencesKeys {
         val language = stringPreferencesKey("language")
-        val transcriptionFontRatio = floatPreferencesKey("transcription_font_ratio")
+        val transcriptFontSize = stringPreferencesKey("transcript_font_size")
         val autoscroll = booleanPreferencesKey("autoscroll")
         val stopRecordingOnFocusLoss = booleanPreferencesKey("stopRecordingOnFocusLoss")
         val generateSpeakerLabels = booleanPreferencesKey("generateSpeakerLabels")
@@ -51,9 +59,9 @@ class UserPreferencesRepository(private val dataStore: DataStore<Preferences>) {
         }
     }
 
-    suspend fun updateTranscriptFontRatio(transcriptFontRatio: Float) {
+    suspend fun updateTranscriptFontSize(transcriptFontSize: FontSizes) {
         dataStore.edit { preferences ->
-            preferences[PreferencesKeys.transcriptionFontRatio] = transcriptFontRatio
+            preferences[PreferencesKeys.transcriptFontSize] = transcriptFontSize.name
         }
     }
 
@@ -79,10 +87,12 @@ class UserPreferencesRepository(private val dataStore: DataStore<Preferences>) {
         val language = Languages.valueOf(
             preferences[PreferencesKeys.language] ?: Languages.ENGLISH_US.name
         )
-        val transcriptFontRatio = preferences[PreferencesKeys.transcriptionFontRatio] ?: 3f
+        val transcriptFontSize = FontSizes.valueOf(
+            preferences[PreferencesKeys.transcriptFontSize] ?: FontSizes.MEDIUM.name
+        )
         val autoscroll = preferences[PreferencesKeys.autoscroll] ?: true
         val stopRecordingOnFocusLoss = preferences[PreferencesKeys.stopRecordingOnFocusLoss] ?: true
         val generateSpeakerLabels = preferences[PreferencesKeys.generateSpeakerLabels] ?: false
-return UserPreferences(language, transcriptFontRatio, autoscroll, stopRecordingOnFocusLoss, generateSpeakerLabels)
+return UserPreferences(language, transcriptFontSize, autoscroll, stopRecordingOnFocusLoss, generateSpeakerLabels)
     }
 }

--- a/app/src/main/java/tech/almost_senseless/voskle/data/UserPreferencesRepository.kt
+++ b/app/src/main/java/tech/almost_senseless/voskle/data/UserPreferencesRepository.kt
@@ -16,11 +16,11 @@ import java.io.IOException
 
 private const val TAG = "PreferencesRepo"
 
-enum class FontSizes(val size: TextUnit) {
-    SMALL(12.sp),
-    MEDIUM(16.sp),
-    LARGE(24.sp),
-    LARGEST(36.sp)
+enum class FontSizes(val size: TextUnit, val lineHeight: TextUnit) {
+    SMALL(12.sp, 18.sp),
+    MEDIUM(16.sp, 24.sp),
+    LARGE(24.sp, 36.sp),
+    LARGEST(36.sp, 54.sp)
 }
 
 data class UserPreferences(

--- a/app/src/main/java/tech/almost_senseless/voskle/ui/customComposables/SettingsDialog.kt
+++ b/app/src/main/java/tech/almost_senseless/voskle/ui/customComposables/SettingsDialog.kt
@@ -1,5 +1,6 @@
 package tech.almost_senseless.voskle.ui.customComposables
 
+import android.annotation.SuppressLint
 import android.content.Context
 import android.content.Intent
 import androidx.compose.foundation.layout.Arrangement
@@ -45,6 +46,7 @@ import tech.almost_senseless.voskle.OSSLicensesActivity
 import tech.almost_senseless.voskle.R
 import tech.almost_senseless.voskle.VLTAction
 import tech.almost_senseless.voskle.VLTState
+import tech.almost_senseless.voskle.data.FontSizes
 import tech.almost_senseless.voskle.data.UserPreferences
 import tech.almost_senseless.voskle.util.ObservableInputStream
 import tech.almost_senseless.voskle.util.UnzipUtils
@@ -102,7 +104,7 @@ fun SettingsDialog(
                     Row(modifier = Modifier.fillMaxWidth()) {
                         Column {
                             Text(text = stringResource(id = R.string.transcript_font_size))
-                            FontRatioRadioButtons(settings = settings, onAction = onAction)
+                            FontSizeRadioButtons(settings = settings, onAction = onAction)
                         }
                     }
                 }
@@ -239,12 +241,12 @@ fun SettingsDialog(
     }
 }
 
+@SuppressLint("DiscouragedApi")
 @Composable
-fun FontRatioRadioButtons(
+fun FontSizeRadioButtons(
     settings: UserPreferences,
     onAction: (VLTAction) -> Unit
 ) {
-    val radioOptions = listOf(3f, 4f, 5f, 6f, 7f)
     Column(
         Modifier
             .selectableGroup()
@@ -253,26 +255,33 @@ fun FontRatioRadioButtons(
                     .padding(horizontal = 5.dp)
             )
     ) {
-        radioOptions.forEach { value ->
+        FontSizes.values().forEach { fontSize ->
             Row(
                 Modifier
                     .fillMaxWidth()
                     .height(56.dp)
                     .selectable(
-                        selected = (value == settings.transcriptFontRatio),
-                        onClick = { onAction(VLTAction.SetTranscriptFontRatio(value)) },
+                        selected = (fontSize == settings.fontSize),
+                        onClick = { onAction(VLTAction.SetTranscriptFontSize(fontSize)) },
                         role = Role.RadioButton
                     )
                     .padding(horizontal = 16.dp),
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 RadioButton(
-                    selected = (value == settings.transcriptFontRatio),
+                    selected = (fontSize == settings.fontSize),
                     onClick = null // null recommended for accessibility with screen readers
                 )
+
+                // We could technically use a mapper function to return the correct string resource
+                // but here it's done dynamically for now.
+                val context = LocalContext.current
+                val fontSizeName = context.getString(context.resources.getIdentifier(
+                    fontSize.name, "string", context.packageName
+                ))
                 Text(
-                    text = "${(value*100).toInt()} %",
-                    fontSize = value.em
+                    text = fontSizeName,
+                    fontSize = fontSize.size
                 )
             }
         }

--- a/app/src/main/java/tech/almost_senseless/voskle/ui/customComposables/Textarea.kt
+++ b/app/src/main/java/tech/almost_senseless/voskle/ui/customComposables/Textarea.kt
@@ -75,7 +75,7 @@ fun Textarea(
                 }
             }
             .then(modifier),
-        textStyle = LocalTextStyle.current.copy(fontSize = settings.fontSize.size),
+        textStyle = LocalTextStyle.current.copy(fontSize = settings.fontSize.size, lineHeight = settings.fontSize.lineHeight),
         keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
         keyboardActions = KeyboardActions(
             onDone = {

--- a/app/src/main/java/tech/almost_senseless/voskle/ui/customComposables/Textarea.kt
+++ b/app/src/main/java/tech/almost_senseless/voskle/ui/customComposables/Textarea.kt
@@ -8,7 +8,6 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.LocalTextStyle
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
@@ -23,13 +22,11 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.em
 import tech.almost_senseless.voskle.R
 import tech.almost_senseless.voskle.VLTAction
 import tech.almost_senseless.voskle.VLTState
 import tech.almost_senseless.voskle.data.UserPreferences
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun Textarea(
     settings: UserPreferences,
@@ -78,7 +75,7 @@ fun Textarea(
                 }
             }
             .then(modifier),
-        textStyle = LocalTextStyle.current.copy(fontSize = settings.transcriptFontRatio.em),
+        textStyle = LocalTextStyle.current.copy(fontSize = settings.fontSize.size),
         keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
         keyboardActions = KeyboardActions(
             onDone = {

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -53,4 +53,8 @@
     <string name="unknown_speaker">Unbekannt:</string>
     <string name="speaker">Person %1$s:</string>
     <string name="download_speaker_model">Modell für Sprechererkkennung herunterladen</string>
+    <string name="SMALL">Klein</string>
+    <string name="MEDIUM">Mittel</string>
+    <string name="LARGE">Groß</string>
+    <string name="LARGEST">Am größten</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -53,4 +53,8 @@
     <string name="unknown_speaker">Unknown:</string>
     <string name="speaker">Person %1$s:</string>
     <string name="download_speaker_model">Download model for speaker recognition</string>
+    <string name="SMALL">Small</string>
+    <string name="MEDIUM">Medium</string>
+    <string name="LARGE">Large</string>
+    <string name="LARGEST">Largest</string>
 </resources>


### PR DESCRIPTION
* Font sizes now get tracked in `sp` instead of `em`.
* Currently, the available sizes are `small`, `medium`, `large` and `largest`.
* The line height also gets adjusted according to the font size.